### PR TITLE
Add since(Long since) methods to Builders; fix another deserialization bug

### DIFF
--- a/disquo-api/src/main/java/net/anthavio/disquo/api/ApiForums.java
+++ b/disquo-api/src/main/java/net/anthavio/disquo/api/ApiForums.java
@@ -130,6 +130,8 @@ public interface ApiForums {
 
 		public ListPostsBuilder since(Date since);
 
+		public ListPostsBuilder since(Long since);
+
 		public ListPostsBuilder related(Related... related);
 
 		public ListPostsBuilder cursor(String cursor);
@@ -164,6 +166,8 @@ public interface ApiForums {
 		public ListThreadsBuilder threadLink(@HttlVar("thread:link") String... threadLink);
 		
 		public ListThreadsBuilder since(Date since);
+
+		public ListThreadsBuilder since(Long since);
 
 		public ListThreadsBuilder related(Related... related);
 

--- a/disquo-api/src/main/java/net/anthavio/disquo/api/ApiThreads.java
+++ b/disquo-api/src/main/java/net/anthavio/disquo/api/ApiThreads.java
@@ -182,6 +182,8 @@ public interface ApiThreads {
 
 		public ListPostsBuilder since(@HttlVar("since") Date since);
 
+		public ListPostsBuilder since(@HttlVar("since") Long since);
+
 		public ListPostsBuilder related(@HttlVar("related") Related... related);
 
 		public ListPostsBuilder include(@HttlVar("include") PostState... include);

--- a/disquo-api/src/main/java/net/anthavio/disquo/api/response/DisqusThreadDeserializer.java
+++ b/disquo-api/src/main/java/net/anthavio/disquo/api/response/DisqusThreadDeserializer.java
@@ -29,7 +29,7 @@ public class DisqusThreadDeserializer extends JsonDeserializer<DisqusThread> {
 		DisqusThread bean = new DisqusThread();
 		while (jp.nextToken() != JsonToken.END_OBJECT) {
 			String field = jp.getCurrentName();
-			jp.nextToken();
+			jp.nextValue();
 			if ("id".equals(field)) {
 				bean.setId(DeserializationUtils.getLong(jp));
 


### PR DESCRIPTION
The existing `since(Date since)` methods in the request builders are a bit tricky to work with because they pass a timezone-d date to Disqus, meaning you actually have to construct a Date that's timezone adjusted. 

Adding since(Long since) allows passing a unix timestamp and bypassing the messiness of this.

Additionally, the ThreadDeserializer suffered from the same issue described in #4 and fixed in #5. This fixes that issue too.  